### PR TITLE
Fixing Logic of framecount

### DIFF
--- a/AnimatedSprite.lua
+++ b/AnimatedSprite.lua
@@ -163,7 +163,7 @@ local function addState(self, params)
 	state.name = params.name
 	if (params.frames ~= nil) then
 		state["frames"] = params.frames -- Custom animation for non-sequential frames from the imagetable
-		params.framesCount = params.framesCount or #params.frames
+		params.framesCount = #params.frames
 		if (type(params.firstFrameIndex) ~= "string") then
 			params.firstFrameIndex = params.firstFrameIndex or 1
 		end


### PR DESCRIPTION
when frames are provided, the length of the frames should be used. Since this variable "framesCount" is already filled by the "end index", the length of the frames integer table would never be set.

You can try that by having an 8 frame walk cycle with only 5 sprite frames, in which frames 2 and 4 are repeated.

asellus.sprite:addState('walk',1,5,{ tickStep = 10, frames = { 1,2,3,2,1,4,5,4 }  })

Without this changes, the walk cycle size "framesCount" will be only 5 ("end frame" parameter) instead of the correct 8 (frame size)